### PR TITLE
Use GitHub releases for asset delivery

### DIFF
--- a/.github/release
+++ b/.github/release
@@ -1,0 +1,87 @@
+#!/usr/bin/env sh
+#
+# Deploy build artifacts as a GitHub release
+# https://github.com/ashenm/environment
+#
+# Ashen Gunaratne
+# mail@ashenm.ml
+#
+
+# errexit
+set -e
+
+# repository
+REPOSITORY="ashenm/environment"
+
+# color escapes
+ANSI_RESET="\033[0m"
+ANSI_YELLOW="\033[33;1m"
+
+# verbosity
+STDOUT=/dev/stdout
+
+# parse args
+while [ $# -ne 0 ]
+do
+
+  case "$1" in
+
+    --silent)
+      STDOUT=/dev/null
+      shift
+      ;;
+
+    --prerelease)
+      PRERELEASE="true"
+      shift
+      ;;
+
+    -*|--*)
+      echo >&2 "Invalid option $1"
+      exit 1
+      ;;
+
+  esac
+
+done
+
+# ensure requisite files
+test -f releases/windows/aliases.cab && test -f releases/linux/sbin.tar && \
+  test -f releases/linux/bin.tar || { echo >&2 "Missing requisit file(s)"; exit 1; }
+
+# tag (latest++)
+TAG_NAME="$(curl --silent --fail --location --show-error --header "Authorization: token $GITHUB_TOKEN" --url "https://api.github.com/repos/$REPOSITORY/tags" \
+  | jq --raw-output '.[0]["name"] // "v0" | match("v(\\d+\\.?\\d*?)(\\.\\d*)?$") | .["captures"][0]["string"] | tonumber + .1 | "v" + tostring')"
+
+# strip preceding decimals
+TAG_NAME="$(expr substr $TAG_NAME 1 4)"
+
+echo 1>$STDOUT "${ANSI_YELLOW}Preparing release ${TAG_NAME}${ANSI_RESET}"
+
+# create new lightweight tag
+curl --silent --fail --show-error --request POST --header "Authorization: token $GITHUB_TOKEN" --output /dev/null --url "https://api.github.com/repos/$REPOSITORY/git/tags" \
+  --data "{ \"tag\": \"$TAG_NAME\", \"message\": \"Deploy $TAG_NAME\", \"object\": \"$(git log --max-count=1 --format="%H")\", \"type\": \"commit\" }"
+
+echo 1>$STDOUT "${ANSI_YELLOW}Deploying ${PRERELEASE+pre-}release${ANSI_RESET}"
+
+# create release
+RELEASE_ID="$(curl --fail --silent --show-error --request POST --header "Authorization: token $GITHUB_TOKEN" --url "https://api.github.com/repos/$REPOSITORY/releases" \
+    --data "{ \"tag_name\": \"$TAG_NAME\", \"target_commitish\": \"$(git log --max-count=1 --format="%H")\", \"name\": \"$TAG_NAME\", \"prerelease\": ${PRERELEASE:-false} }" | jq --raw-output '.id')"
+
+echo 1>$STDOUT "${ANSI_YELLOW}Uploading artifact aliases.cab${ANSI_RESET}"
+
+# upload aliases.cab
+curl --silent --fail --show-error --request POST --header "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/vnd.ms-cab-compressed" \
+  --data-binary "@releases/windows/aliases.cab" --output /dev/null --url "https://uploads.github.com/repos/$REPOSITORY/releases/$RELEASE_ID/assets?name=aliases.cab&label=Windows%20Binaries"
+  
+echo 1>$STDOUT "${ANSI_YELLOW}Uploading artifact sbin.tar${ANSI_RESET}"
+
+# upload sbin.tar
+curl --silent --fail --show-error --request POST --header "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/x-tar" \
+  --data-binary "@releases/linux/sbin.tar" --output /dev/null --url "https://uploads.github.com/repos/$REPOSITORY/releases/$RELEASE_ID/assets?name=sbin.tar&label=Linux%20System%20Binaries"
+
+echo 1>$STDOUT "${ANSI_YELLOW}Uploading artifact bin.tar${ANSI_RESET}"
+
+# upload bin.tar
+curl --silent --fail --show-error --request POST --header "Authorization: token $GITHUB_TOKEN" --header "Content-Type: application/x-tar" \
+  --data-binary "@releases/linux/bin.tar" --output /dev/null --url "https://uploads.github.com/repos/$REPOSITORY/releases/$RELEASE_ID/assets?name=bin.tar&label=Linux%20Binaries"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ dist:
 language:
   minimal
 
+branches:
+  except:
+    /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
 install:
   make install
 
@@ -11,13 +15,15 @@ script:
   make build
 
 deploy:
-  provider: pages
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN
-  target_branch: $(echo releases-$TRAVIS_BRANCH | sed 's/^releases-master$/releases/')
-  local_dir: releases
-  on:
-    all_branches: true
+  - provider: script
+    script: ./.github/release
+    on:
+      branch: master
+  - provider: script
+    script: ./.github/release --prerelease
+    on:
+      all_branches: true
+      condition: $TRAVIS_BRANCH != master
 
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ deploy:
     script: ./.github/release
     on:
       branch: master
+    skip_cleanup: true
   - provider: script
     script: ./.github/release --prerelease
     on:
       all_branches: true
       condition: $TRAVIS_BRANCH != master
+    skip_cleanup: true
 
 notifications:
   slack:

--- a/linux/setup
+++ b/linux/setup
@@ -18,12 +18,12 @@ test `id -u` -ne 0 && {
 
 # install bin shims
 curl --silent --show-error --output - \
-    --url https://raw.githubusercontent.com/ashenm/environment/releases/linux/bin.tar | \
+    --url https://github.com/ashenm/environment/releases/latest/download/bin.tar | \
   tar --extract --overwrite --preserve-permissions --file - --directory /
 
 # install sbin shims
 curl --silent --show-error --output - \
-    --url https://raw.githubusercontent.com/ashenm/environment/releases/linux/sbin.tar | \
+    --url https://github.com/ashenm/environment/releases/latest/download/sbin.tar | \
   tar --extract --overwrite --preserve-permissions --file - --directory /
 
 # baseimage.sh

--- a/windows/setup.cmd
+++ b/windows/setup.cmd
@@ -11,7 +11,7 @@
 
 :: install alias shims
 BITSADMIN /TRANSFER environment-aliases /DOWNLOAD ^
-    https://raw.githubusercontent.com/ashenm/environment/releases/windows/aliases.cab %TEMP%\environment-aliases.cab >> NUL && (
+    https://github.com/ashenm/environment/releases/latest/download/aliases.cab %TEMP%\environment-aliases.cab >> NUL && (
   MKDIR %USERPROFILE%\.environment\aliases
   EXPAND -R %TEMP%\environment-aliases.cab %USERPROFILE%\.environment\aliases >> NULL
   DEL /F /Q %TEMP%\environment-aliases.cab


### PR DESCRIPTION
- Deploys build artefacts to GitHub releases rather than `releases-<BRANCH_NAME>`
- Resolves #6 since no longer releasing artefacts to individual cluttering branches